### PR TITLE
feat: support validation of certificate against a CA

### DIFF
--- a/cmd/yubico-piv-checker/main.go
+++ b/cmd/yubico-piv-checker/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"crypto/x509"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -13,19 +15,95 @@ func init() {
 	log.SetOutput(os.Stderr)
 }
 
+func loadCertificatePool(filePath string) (*x509.CertPool, error) {
+	if filePath == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA file: %w", err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(data) {
+		return nil, fmt.Errorf("failed to parse CA certificates")
+	}
+
+	return pool, nil
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, "Usage:\n")
+	fmt.Fprintf(os.Stderr, "  Certificate mode: %s -cert <certificate> -attestation <attestation> -key-cert <key-certificate> [-ca <ca-file>]\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "  SSH Key mode (legacy): %s <ssh-key> <attestation> <key-certificate>\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "\nFlags:\n")
+	fmt.Fprintf(os.Stderr, "  -cert string\n")
+	fmt.Fprintf(os.Stderr, "      User certificate from slot 9a\n")
+	fmt.Fprintf(os.Stderr, "  -attestation string\n")
+	fmt.Fprintf(os.Stderr, "        Attestation certificate for slot 9a\n")
+	fmt.Fprintf(os.Stderr, "  -key-cert string\n")
+	fmt.Fprintf(os.Stderr, "        Attestation key from slot f9\n")
+	fmt.Fprintf(os.Stderr, "  -ca string\n")
+	fmt.Fprintf(os.Stderr, "        Path to the CA certificate to validate cert from slot 9a\n")
+}
+
 func main() {
-	if len(os.Args) != 4 {
-		fmt.Fprintf(os.Stderr, "Usage: %s ssh-key attestation key-certificate\n", os.Args[0])
-		os.Exit(-1)
-	}
+	var (
+		certFlag        = flag.String("cert", "", "User certificate file or content")
+		attestationFlag = flag.String("attestation", "", "Attestation certificate file or content")
+		keyCertFlag     = flag.String("key-cert", "", "Key certificate file or content")
+		caFlag          = flag.String("ca", "", "Trusted CA certificates file (optional)")
+	)
 
-	r, err := checker.VerifySSHKey(os.Args[1], os.Args[2], os.Args[3])
-	if err != nil {
-		log.Fatal(err)
-	}
+	flag.Parse()
 
-	err = json.NewEncoder(os.Stdout).Encode(r)
-	if err != nil {
-		log.Fatal(err)
+	// Check if using new certificate mode
+	if *certFlag != "" || *attestationFlag != "" || *keyCertFlag != "" {
+		if *certFlag == "" || *attestationFlag == "" || *keyCertFlag == "" {
+			fmt.Fprintf(os.Stderr, "Error: -cert, -attestation, and -key-cert are all required for certificate mode\n\n")
+			printUsage()
+			os.Exit(-1)
+		}
+
+		// Read certificate content
+		userCert := *certFlag
+		attestation := *attestationFlag
+		keyCert := *keyCertFlag
+
+		// Load trusted CAs if provided
+		trustedCAs, err := loadCertificatePool(*caFlag)
+		if err != nil {
+			log.Fatalf("Failed to load trusted CAs: %v", err)
+		}
+
+		// Verify certificate
+		r, err := checker.VerifyCertificate(userCert, attestation, keyCert, trustedCAs)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = json.NewEncoder(os.Stdout).Encode(r)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+	} else {
+		// Backwards compatibility
+		if len(os.Args) != 4 {
+			fmt.Fprintf(os.Stderr, "Error: Wrong number of arguments for SSH key mode\n\n")
+			printUsage()
+			os.Exit(-1)
+		}
+
+		r, err := checker.VerifySSHKey(os.Args[1], os.Args[2], os.Args[3])
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = json.NewEncoder(os.Stdout).Encode(r)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 }

--- a/lib/checker/checker.go
+++ b/lib/checker/checker.go
@@ -2,10 +2,15 @@ package checker
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/asn1"
+	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"time"
 
 	"github.com/ovh/yubico-piv-checker/lib/types"
 
@@ -21,6 +26,187 @@ func parseCertificate(cert string) (*x509.Certificate, error) {
 	return x509.ParseCertificate(block.Bytes)
 }
 
+// deriveSSHKeyFromCertificate extracts the public key from an x509 certificate
+// and converts it to an SSH public key, supporting RSA, ECDSA, and Ed25519
+func deriveSSHKeyFromCertificate(cert *x509.Certificate) (ssh.PublicKey, string, error) {
+	var keyType string
+
+	switch pub := cert.PublicKey.(type) {
+	case *rsa.PublicKey:
+		keyType = "RSA"
+	case *ecdsa.PublicKey:
+		keyType = "ECDSA"
+	case ed25519.PublicKey:
+		keyType = "Ed25519"
+	default:
+		return nil, "", fmt.Errorf("unsupported key type: %T", pub)
+	}
+
+	sshPubKey, err := ssh.NewPublicKey(cert.PublicKey)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to convert certificate public key to SSH key: %w", err)
+	}
+
+	return sshPubKey, keyType, nil
+}
+
+// validateCertificateChain validates that the certificate was signed by a trusted CA
+func validateCertificateChain(cert *x509.Certificate, trustedRoots *x509.CertPool) ([]string, error) {
+	opts := x509.VerifyOptions{
+		Roots: trustedRoots,
+	}
+
+	chains, err := cert.Verify(opts)
+	if err != nil {
+		return nil, fmt.Errorf("certificate validation failed: %w", err)
+	}
+
+	// Extract the CA chain
+	var caChain []string
+	if len(chains) > 0 {
+		for _, cert := range chains[0] {
+			caChain = append(caChain, cert.Subject.CommonName)
+		}
+	}
+
+	return caChain, nil
+}
+
+// formatKeyUsage converts x509.KeyUsage to human-readable strings
+func formatKeyUsage(usage x509.KeyUsage) []string {
+	var usages []string
+
+	if usage&x509.KeyUsageDigitalSignature != 0 {
+		usages = append(usages, "Digital Signature")
+	}
+	if usage&x509.KeyUsageContentCommitment != 0 {
+		usages = append(usages, "Content Commitment")
+	}
+	if usage&x509.KeyUsageKeyEncipherment != 0 {
+		usages = append(usages, "Key Encipherment")
+	}
+	if usage&x509.KeyUsageDataEncipherment != 0 {
+		usages = append(usages, "Data Encipherment")
+	}
+	if usage&x509.KeyUsageKeyAgreement != 0 {
+		usages = append(usages, "Key Agreement")
+	}
+	if usage&x509.KeyUsageCertSign != 0 {
+		usages = append(usages, "Certificate Sign")
+	}
+	if usage&x509.KeyUsageCRLSign != 0 {
+		usages = append(usages, "CRL Sign")
+	}
+	if usage&x509.KeyUsageEncipherOnly != 0 {
+		usages = append(usages, "Encipher Only")
+	}
+	if usage&x509.KeyUsageDecipherOnly != 0 {
+		usages = append(usages, "Decipher Only")
+	}
+
+	return usages
+}
+
+// VerifyCertificate verifies an x509 certificate against Yubikey PIV attestation
+// and validates the certificate chain against trusted CAs
+func VerifyCertificate(userCert string, attestation string, keyCertificate string, trustedCARoots *x509.CertPool) (*types.Result, error) {
+	// Parse user certificate
+	cert, err := parseCertificate(userCert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse user certificate: %w", err)
+	}
+
+	// Derive SSH key from certificate
+	sshPubKey, keyType, err := deriveSSHKeyFromCertificate(cert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive SSH key from certificate: %w", err)
+	}
+
+	// Parse attestation and check associated public key
+	att, err := parseCertificate(attestation)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse attestation: %w", err)
+	}
+	attPubKey, err := ssh.NewPublicKey(att.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute SSH Key from attestation: %w", err)
+	}
+	if !bytes.Equal(sshPubKey.Marshal(), attPubKey.Marshal()) {
+		return nil, fmt.Errorf("certificate public key doesn't match attestation")
+	}
+
+	// Parse key certificate and verify attestation signature
+	keyCert, err := parseCertificate(keyCertificate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Key Certificate: %w", err)
+	}
+	err = keyCert.CheckSignature(att.SignatureAlgorithm, att.RawTBSCertificate, att.Signature)
+	if err != nil {
+		return nil, fmt.Errorf("invalid attestation signature: %w", err)
+	}
+
+	// Verify key certificate against Yubikey CA
+	_, err = keyCert.Verify(x509.VerifyOptions{Roots: yubiCertPoolRoots, Intermediates: yubiCertPoolIntermediates})
+	if err != nil {
+		return nil, fmt.Errorf("invalid Key Certificate signature: %w", err)
+	}
+
+	// Validate user certificate against trusted CAs if provided
+	var caChain []string
+	var isValidCA bool
+	if trustedCARoots != nil {
+		caChain, err = validateCertificateChain(cert, trustedCARoots)
+		if err != nil {
+			// Don't fail completely, just mark as not validated
+			isValidCA = false
+		} else {
+			isValidCA = true
+		}
+	}
+
+	if !isValidCA && trustedCARoots != nil {
+		return nil, fmt.Errorf("user certificate validation against trusted CAs failed")
+	}
+
+	// Build result
+	var r types.Result
+
+	// SSH Key information
+	r.SSHKey.FingerprintMD5 = ssh.FingerprintLegacyMD5(sshPubKey)
+	r.SSHKey.FingerprintSHA = ssh.FingerprintSHA256(sshPubKey)
+	r.SSHKey.Type = keyType
+	r.SSHKey.PublicKey = string(ssh.MarshalAuthorizedKey(sshPubKey))
+
+	// Certificate information
+	r.Certificate.Subject = cert.Subject.String()
+	r.Certificate.Issuer = cert.Issuer.String()
+	r.Certificate.SerialNumber = hex.EncodeToString(cert.SerialNumber.Bytes())
+	r.Certificate.NotBefore = cert.NotBefore.Format(time.RFC3339)
+	r.Certificate.NotAfter = cert.NotAfter.Format(time.RFC3339)
+	r.Certificate.KeyUsage = formatKeyUsage(cert.KeyUsage)
+	r.Certificate.IsValidCA = isValidCA
+	r.Certificate.TrustedCAPath = caChain
+
+	// Extract Yubikey Metadata from attestation
+	for _, e := range att.Extensions {
+		if e.Id.Equal(oidExtensionYubikeySerialNumber) {
+			var serialNumber int
+			if _, err := asn1.Unmarshal(e.Value, &serialNumber); err == nil {
+				r.Yubikey.SerialNumber = serialNumber
+			}
+		} else if e.Id.Equal(oidExtensionYubikeyFirmware) && len(e.Value) == 3 {
+			r.Yubikey.FirmwareVersion = fmt.Sprintf("%d.%d.%d", e.Value[0], e.Value[1], e.Value[2])
+		} else if e.Id.Equal(oidExtensionYubikeyPolicy) && len(e.Value) == 2 {
+			r.Yubikey.PinPolicy = types.YubicoPinPolicy(e.Value[0])
+			r.Yubikey.TouchPolicy = types.YubicoTouchPolicy(e.Value[1])
+		}
+	}
+
+	return &r, nil
+}
+
+// VerifySSHKey is maintained for backward compatibility
+// Deprecated: Use VerifyCertificate instead
 func VerifySSHKey(sshKey string, attestation string, keyCertificate string) (*types.Result, error) {
 	sshPubKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(sshKey))
 	if err != nil {
@@ -58,6 +244,18 @@ func VerifySSHKey(sshKey string, attestation string, keyCertificate string) (*ty
 	var r types.Result
 	r.SSHKey.FingerprintMD5 = ssh.FingerprintLegacyMD5(sshPubKey)
 	r.SSHKey.FingerprintSHA = ssh.FingerprintSHA256(sshPubKey)
+
+	// Determine key type from SSH key
+	switch sshPubKey.Type() {
+	case "ssh-rsa":
+		r.SSHKey.Type = "RSA"
+	case "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521":
+		r.SSHKey.Type = "ECDSA"
+	case "ssh-ed25519":
+		r.SSHKey.Type = "Ed25519"
+	default:
+		r.SSHKey.Type = "Unknown"
+	}
 
 	// Extract Key Metadata
 	for _, e := range att.Extensions {

--- a/lib/types/types.go
+++ b/lib/types/types.go
@@ -22,6 +22,19 @@ const (
 type SSHKey struct {
 	FingerprintMD5 string
 	FingerprintSHA string
+	Type           string // RSA, ECDSA, Ed25519
+	PublicKey      string
+}
+
+type Certificate struct {
+	Subject       string
+	Issuer        string
+	SerialNumber  string
+	NotBefore     string
+	NotAfter      string
+	KeyUsage      []string
+	IsValidCA     bool
+	TrustedCAPath []string // Chain of trusted CAs
 }
 
 type Yubikey struct {
@@ -32,6 +45,7 @@ type Yubikey struct {
 }
 
 type Result struct {
-	SSHKey  SSHKey
-	Yubikey Yubikey
+	SSHKey      SSHKey
+	Certificate Certificate
+	Yubikey     Yubikey
 }


### PR DESCRIPTION
Hi,

This PR extends the validation capabilities of the `yubico-piv-checker` by not only validating the ssh key against the attestation key, but also verifying that the certificate was signed by a trusted CA.

My idea is to implement this feature for The Bastion, so that I can ensure that PIV keys are actually signed by a trusted CA.
The changes for The Bastion to support this are still to be done, but this PR is the foundation for this feature.


The PR is implemented in a none breaking way, so that you can still provide an ssh key, attestation key etc. as command args, but now you also have an option to pass those as flags to use the CA validation feature.